### PR TITLE
fix: DatabaseクラスがTOFセンサーを適切に取得できるよう修正

### DIFF
--- a/include/Provider/Database.hpp
+++ b/include/Provider/Database.hpp
@@ -7,21 +7,22 @@
 class Database
 {
 public:
-    Database(Imu &imu, TimeOfFlightSensor time_of_flight_sensor, LimitSwitch front_limit_switch, LimitSwitch side_limit_switch);
+    Database(Imu &imu, TimeOfFlightSensor front_time_of_flight_sensor, TimeOfFlightSensor side_time_of_flight_sensor, LimitSwitch front_limit_switch, LimitSwitch side_limit_switch);
     // x, y方向の加速度[m/s^2]を取得する
     std::pair<double, double> getAcceleration();
     // 角速度[rad/s]を取得する
     double getAngularVelocity();
     // 赤外線センサー1の値を取得する
-    bool isDetecting_1();
+    bool getFrontTofStatus();
     // 赤外線センサー2の値を取得する
-    bool isDetecting_2();
+    bool getSideTofStatus();
     bool getFrontLimitSwitchStatus();
     bool getSideLimitSwitchStatus();
 
 private:
     Imu &imu;
-    TimeOfFlightSensor time_of_flight_sensor;
+    TimeOfFlightSensor front_time_of_flight_sensor;
+    TimeOfFlightSensor side_time_of_flight_sensor;
     LimitSwitch front_limit_switch;
     LimitSwitch side_limit_switch;
 };

--- a/src/Provider/Database.cpp
+++ b/src/Provider/Database.cpp
@@ -1,8 +1,8 @@
 #include "Provider/Database.hpp"
 #include <math.h>
 
-Database::Database(Imu &imu, TimeOfFlightSensor time_of_flight_sensor, LimitSwitch front_limit_switch, LimitSwitch side_limit_switch)
-    : imu(imu), time_of_flight_sensor(time_of_flight_sensor), front_limit_switch(front_limit_switch), side_limit_switch(side_limit_switch)
+Database::Database(Imu &imu, TimeOfFlightSensor front_time_of_flight_sensor, TimeOfFlightSensor side_time_of_flight_sensor, LimitSwitch front_limit_switch, LimitSwitch side_limit_switch)
+    : imu(imu), front_time_of_flight_sensor(front_time_of_flight_sensor), side_time_of_flight_sensor(side_time_of_flight_sensor), front_limit_switch(front_limit_switch), side_limit_switch(side_limit_switch)
 {
     this->imu.init();
     front_limit_switch.init();
@@ -21,14 +21,14 @@ double Database::getAngularVelocity()
     return imu.getAngularVelocity().z * 180. / M_PI;
 }
 
-bool Database::isDetecting_1()
+bool Database::getFrontTofStatus()
 {
-    return time_of_flight_sensor.isDetecting_1();
+    return front_time_of_flight_sensor.isDetecting_1();
 }
 
-bool Database::isDetecting_2()
+bool Database::getSideTofStatus()
 {
-    return time_of_flight_sensor.isDetecting_2();
+    return front_time_of_flight_sensor.isDetecting_1();
 }
 
 bool Database::getFrontLimitSwitchStatus()


### PR DESCRIPTION
isDetecting の1,2は、同一の赤外線センサーで2つの値を閾値に設定できることに起因している。今回は、センサーを2つ使用＆閾値はとりあえず１つ用意という設計なので、メンバー変数をFront/Sideの2種類用意＆isDetecting_1のみを使用という形式に修正した。
それに伴い、メソッド名にも変更を加えた。