### PR TITLE
リミットスイッチの内部抵抗を利用した実装を削除

### DIFF
--- a/src/Parts/LimitSwitch.cpp
+++ b/src/Parts/LimitSwitch.cpp
@@ -64,7 +64,7 @@ bool LimitSwitch::debounce(bool rawState) {
     // SS-10GL13に最適化された30msデバウンス時間
     // この時間はSS-10GL13のSimulated Roller Leverの
     // 機械的応答時間と接点バウンス特性を考慮
-    if (debounceTimer.read_ms() > DEBOUNCE_TIME_MS) {
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(debounceTimer.elapsed_time()).count() > DEBOUNCE_TIME_MS) {
         // 十分な時間が経過 → 状態を確定
         if (rawState != currentState) {
             currentState = rawState;

--- a/src/Parts/LimitSwitch.cpp
+++ b/src/Parts/LimitSwitch.cpp
@@ -6,21 +6,21 @@ LimitSwitch::LimitSwitch(PinName pin) : digitalIn(pin), lastState(false), curren
 }
 
 void LimitSwitch::init() {
-     // SS-10GL13専用設定
+    // SS-10GL13専用設定
     // COM → Mbedピン, NC → GND の配線構成
-    // 非押下時: NC-COM間導通でLOW (0V)
-    // 押下時: NC-COM間切断、プルアップでHIGH (3.3V)
-    digitalIn.mode(PullUp);
+    // 外部にプルダウン抵抗があるため、内部プルアップは不要
+    // digitalIn.mode(PullUp);
     
     // SS-10GL13の安定化待機
     // 機械的応答と電気的安定性を確保
     ThisThread::sleep_for(chrono::milliseconds(STABILIZE_TIME_MS));
     
     // 初期状態を安定的に取得
-    bool initialRawState = digitalIn.read(); 
-    currentState = initialRawState;
-    lastState = initialRawState;
-    lastEdgeState = initialRawState;
+    bool initialRawState = getRawInput();
+    // 初期状態は反転させて保存 (NC → GND をプルダウンしているため)
+    currentState = !initialRawState;
+    lastState = !initialRawState;
+    lastEdgeState = !initialRawState;
     
     // デバウンスタイマーリセット
     debounceTimer.reset();
@@ -28,10 +28,10 @@ void LimitSwitch::init() {
 
 bool LimitSwitch::isPressed() {
     // 生入力値取得
-    bool rawState = digitalIn.read();
+    bool rawState = getRawInput();
     
     // SS-10GL13専用デバウンス処理
-    return debounce(rawState);
+    return debounce(!rawState);
 }
 
 bool LimitSwitch::isPressedEdge() {


### PR DESCRIPTION
外部にプルダウン抵抗があるので不要